### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 selenium==3.141.0
+urllib3==1.26.6
 robotframework
 robotframework-appiumlibrary


### PR DESCRIPTION
added urllib3==1.26.6 in requirements.txt as without it this repo is breaking and test fails with below error:
[ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: No application is open
Example of connecting to Lambdatest via Robot Framework               | FAIL |
Setup failed:
ValueError: Timeout value connect was <object object at 0x10e16eb50>, but it must be an int, float or None.
------------------------------------------------------------------------------